### PR TITLE
chore: migrate action runtime to node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '24'
         cache: 'npm'
     - run: npm i -g @vercel/ncc
     - run: npm run build

--- a/action.yml
+++ b/action.yml
@@ -34,5 +34,5 @@ inputs:
     required: false
 
 runs:
-  using: node20
+  using: node24
   main: dist/index.js


### PR DESCRIPTION
## 배경
GitHub Actions가 JavaScript 액션의 **node20 런타임을 곧 제거**할 예정입니다. 액션이 계속 동작하도록 런타임을 최신 지원 버전인 **node24**로 올립니다.

> 참고: Node.js 26이 릴리스되긴 했으나, 최신 러너(v2.335.1)가 액션 런타임으로 번들한 건 `node20`/`node24` 뿐입니다. `using: node26`은 아직 지원되지 않으므로 **node24가 현재 사용 가능한 최신값**입니다.

## 변경 사항
- `action.yml`: `using: node20` → `node24`
- `.github/workflows/ci.yml`:
  - `actions/checkout` `@v3` → `@v6`
  - `actions/setup-node` `@v3` → `@v6`
  - `node-version` `'20'` → `'24'` (액션 런타임과 일치)

## 검증
- 전체 저장소에서 node 버전/액션 참조 전수 검사 완료
- 소스 코드(`index.js`, `utils/`)는 node24 호환, 변경 불필요
- README에는 node 버전 언급 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)